### PR TITLE
Fix for stack overflow on Linux.

### DIFF
--- a/src/NJsonSchema.Tests/Infrastructure/ReflectionCacheTests.cs
+++ b/src/NJsonSchema.Tests/Infrastructure/ReflectionCacheTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema.Infrastructure;
+
+namespace NJsonSchema.Tests.Infrastructure
+{
+    [TestClass]
+    public class ReflectionCacheTests
+    {
+        public class TestClass
+        {
+            public string field;
+
+            public static string staticField;
+
+            public string property { get; set; }
+
+            public static string staticProperty { get; set; }
+        }
+
+        [TestMethod]
+        public void Static_members_are_not_returned_from_ReflectionCache()
+        {
+            //// Act
+            var propertiesAndFields = ReflectionCache.GetPropertiesAndFields(typeof(TestClass));
+
+            //// Assert
+            Assert.IsTrue(propertiesAndFields.Any(p => p.MemberInfo.Name == "field"));
+            Assert.IsFalse(propertiesAndFields.Any(p => p.MemberInfo.Name == "staticField"));
+            Assert.IsTrue(propertiesAndFields.Any(p => p.MemberInfo.Name == "property"));
+            Assert.IsFalse(propertiesAndFields.Any(p => p.MemberInfo.Name == "staticProperty"));
+        }
+   }
+}

--- a/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
+++ b/src/NJsonSchema.Tests/NJsonSchema.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Generation\TypeMapperTests.cs" />
     <Compile Include="Generation\XmlDocTests.cs" />
     <Compile Include="Generation\XmlObjectTests.cs" />
+    <Compile Include="Infrastructure\ReflectionCacheTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="Validation\EnumValidationTests.cs" />
     <Compile Include="Validation\FormatTimeSpanTests.cs" />

--- a/src/NJsonSchema.Tests/Schema/JsonSchemaTests.cs
+++ b/src/NJsonSchema.Tests/Schema/JsonSchemaTests.cs
@@ -148,6 +148,23 @@ namespace NJsonSchema.Tests.Schema
         }
 
         [TestMethod]
+        public async Task When_deserializing_schema_it_should_not_stackoverflow()
+        {
+            //// Arrange
+            var data =
+@"{
+    ""x-dateTime"": ""2016-07-28T14:39:37.937Z""
+}";
+
+            //// Act
+            var schema = await JsonSchema4.FromJsonAsync(data);
+            var x = schema.ToJson();
+
+            //// Assert
+            Assert.IsInstanceOfType(schema.ExtensionData.First().Value, typeof(DateTime));
+        }
+
+        [TestMethod]
         public void When_setting_single_type_then_it_should_be_serialized_correctly()
         {
             //// Arrange

--- a/src/NJsonSchema/Infrastructure/ReflectionCache.cs
+++ b/src/NJsonSchema/Infrastructure/ReflectionCache.cs
@@ -31,8 +31,8 @@ namespace NJsonSchema.Infrastructure
                 if (!PropertyCacheByType.ContainsKey(type))
                 {
 #if !LEGACY
-                    var declaredProperties = type.GetRuntimeProperties();
-                    var declaredFields = type.GetRuntimeFields().Where(f => f.IsPublic);
+                    var declaredProperties = type.GetRuntimeProperties().Where(p => p.GetMethod?.IsStatic != true);
+                    var declaredFields = type.GetRuntimeFields().Where(f => f.IsPublic && !f.IsStatic);
 #else
                     var declaredProperties = type.GetTypeInfo().GetProperties(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
                         .Where(p => p.GetGetMethod(true)?.IsAssembly == true || p.GetGetMethod(true)?.IsPublic == true ||


### PR DESCRIPTION
The `DateTime.Now` static property was being visited
which may return a unique value every time, allowing
unbounded recursion.